### PR TITLE
Switch form loading timeout to CSS animation

### DIFF
--- a/_collections/_forms/test-fail.md
+++ b/_collections/_forms/test-fail.md
@@ -1,0 +1,9 @@
+---
+podio:
+  app: 21577376
+  form: 15020094324
+---
+
+### Test Podio Webform
+
+This form should never load.

--- a/_layouts/form.html
+++ b/_layouts/form.html
@@ -16,9 +16,9 @@ scripts:
 
 <div class="form-embed loading" id="podio-webform-wrapper">
   <div class="loading-overlay">
-    <h1>Loading</h1>
+    <div class="loading-text">Loading</div>
     <div class="timeout-content">
-      <a href="{{ formUrl }}" class="btn btn-text">Not working?</a>
+      <a href="{{ formUrl }}" class="btn btn-text timeout-btn">Not working?</a>
     </div>
   </div>
   <iframe class="podio-webform-frame" id="podio-webform" height="200" data-src="{{ embedUrl }}"></iframe>

--- a/_sass/_form-embed.scss
+++ b/_sass/_form-embed.scss
@@ -9,24 +9,9 @@
     text-align: center;
     color: #444;
 
-    transition: hover-transition(padding-top);
-
     .timeout-content {
       visibility: hidden;
       opacity: 0;
-
-      transition: visibility 0s, hover-transition(opacity);
-    }
-  }
-
-  &.timeout {
-    .loading-overlay {
-      padding-top: 0.5rem;
-
-      .timeout-content {
-        visibility: visible;
-        opacity: 1;
-      }
     }
   }
 
@@ -62,7 +47,37 @@
         to { background-position: 20rem 0; }
       }
 
-      animation: stripes 10s linear infinite;
+      @keyframes timeout-overlay {
+        to { padding-top: 1.5rem; }
+      }
+
+      $time: $hover-transition-time * 2;
+      $curve: $hover-transition-curve;
+
+      animation: stripes 10s linear infinite,
+                 $time $curve 2s 1 normal forwards running timeout-overlay;
+
+      .loading-text {
+        @include h1;
+
+        @keyframes timeout-text {
+          to { @include h2; }
+        }
+
+        animation: $time $curve 2s 1 normal forwards running timeout-text;
+      }
+
+      .timeout-content {
+        @keyframes timeout-content {
+          to { visibility: visible; opacity: 1; }
+        }
+
+        animation: $time $curve 2s 1 normal forwards running timeout-content;
+      }
+
+      .timeout-btn:not(:hover) {
+        background-color: rgba(255, 255, 255, 0.2);
+      }
     }
   }
 

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -1,5 +1,5 @@
 @function hover-transition($prop) {
-  @return #{"#{$prop} #{$hover-transition-time} cubic-bezier(0.4, 0, 0.2, 1)"};
+  @return #{"#{$prop} #{$hover-transition-time} #{$hover-transition-curve}"};
 }
 
 @mixin overlay {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -73,3 +73,4 @@ $overlay-transition-func:   ease-in-out;
 $card-border-radius:        0;
 
 $hover-transition-time:     280ms;
+$hover-transition-curve:    cubic-bezier(0.4, 0, 0.2, 1);

--- a/assets/js/form.js
+++ b/assets/js/form.js
@@ -14,12 +14,6 @@ x.onPageLoad(() => {
 
     x.resizeFrame(frame, wrapper, e);
   });
-
-  window.setTimeout(() => {
-    if (wrapper.classList.contains('loading')) {
-      wrapper.classList.add('timeout');
-    }
-  }, 5000);
 });
 
 x.extend({


### PR DESCRIPTION
### Describe your changes
<!-- A clear and concise description of your changes. -->
 - Remove JS timeout trigger.
 - Add CSS animation with delay.
 - Add test page with invalid form details to always enter timeout state.

### Side effects of your changes
<!-- A clear and concise description of any potentially unexpected results. -->
 - Some older browsers may fail to ever display the *Not working?* button.

### Additional context
<!-- Add any other context about the fix here. -->