### PR TITLE
Added redirect to mitigate typo in email

### DIFF
--- a/_collections/_recruitment/student-speakers.md
+++ b/_collections/_recruitment/student-speakers.md
@@ -20,6 +20,9 @@ brief:
   future: |
     Soon we will be opening applications for speakers at our Student Salon. For
     now, why not check out some of [our previous events](/events)?
+
+redirect_from:
+  /get-involved/student-speaker
 ---
 
 ## Speak at the TEDxWarwick Student Salon


### PR DESCRIPTION
### Describe your changes
<!-- A clear and concise description of your changes. -->
The email advertising student speaker applications contained an incorrect link (`/student-speaker` instead of `/student-speakers`). This is a temporary fix to redirect the bad link to the correct one.

### Side effects of your changes
<!-- A clear and concise description of any potentially unexpected results. -->
The recruitment page `student-speaker` is not available for use until the redirect is retired.

### Additional context
<!-- Add any other context about the fix here. -->
Mailchimp link report showing incorrect link URL:
<img width="400" alt="Mailchimp link report" src="https://user-images.githubusercontent.com/2152582/48160025-b6a1d680-e2ce-11e8-87d2-7b030d198a06.png">
