### PR TITLE
Add facebook messenger plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,6 +111,7 @@ cta:
     link: "/tickets"
 
 fb-app-id: "600131706999745"
+fb-page-id: "50068264676"
 fb-page: "TEDxWarwick"
 twitter-handle: "TEDxWarwick"
 instagram-handle: "tedxwarwick"

--- a/_includes/page/links.html
+++ b/_includes/page/links.html
@@ -41,7 +41,7 @@
 {%- comment %}
     Social SDKs
 {% endcomment %}
-<script type="application/javascript" src="https://connect.facebook.net/en_GB/sdk.js" defer id="facebook-jssdk"></script>
+<script type="application/javascript" src="https://connect.facebook.net/en_GB/sdk/xfbml.customerchat.js" defer id="facebook-jssdk"></script>
 <script type="application/javascript" src="https://platform.twitter.com/widgets.js" defer></script>
 {%- comment %}<script type="application/javascript" src="https://chimpstatic.com/mcjs-connected/js/users/ea80fc5757428ff05bc3da2b6/0dd8af5546dbef99fe77e42e5.js" defer></script>{% endcomment %}
 {%- comment %}

--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -39,5 +39,12 @@
     {% include page/footer.html %}
   </div>
   <div id="overlay"></div>
+  <div class="fb-customerchat"
+    attribution="setup_tool"
+    page_id="{{ site.fb-page-id }}"
+    theme_color="#da291c"
+    logged_in_greeting="Questions? We’re here to answer them."
+    logged_out_greeting="Questions? We’re here to answer them.">
+  </div>
 </body>
 </html>


### PR DESCRIPTION
### Describe your changes
<!-- A clear and concise description of your changes. -->

Added Facebook’s “Customer Chat Plugin”. Not sure if this is something we *need*, but it seemed like a nice idea. Will leave this PR open for thoughts & suggestions.

### Side effects of your changes
<!-- A clear and concise description of any potentially unexpected results. -->

 - Original FB SDK is no longer useable, the replacement `sdk/xfbml.customerchat.js` appears to be a superset though.

### Additional context
<!-- Add any other context about the fix here. -->

Documentation: https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin/