### PR TITLE
Update recruitment for 2020

### DIFF
--- a/_collections/_forms/coordinator-recruitment-2020.md
+++ b/_collections/_forms/coordinator-recruitment-2020.md
@@ -1,0 +1,14 @@
+---
+podio:
+  app: 22451460
+  form: 1582224
+
+nav: recruitment
+---
+
+### TEDxWarwick 2020 Coordinator Recruitment
+
+Please use this form to apply for a Coordinator position for TEDxWarwick 2020,
+and be sure to attach your CV at the bottom. Note that you may apply for both a
+Coordinator and Director position; these applications will be considered
+independently and will not influence each other.

--- a/_collections/_forms/director-recruitment-2020.md
+++ b/_collections/_forms/director-recruitment-2020.md
@@ -1,0 +1,14 @@
+---
+podio:
+  app: 22451462
+  form: 1582225
+
+nav: recruitment
+---
+
+### TEDxWarwick 2020 Director Recruitment
+
+Please use this form to apply for a director position for TEDxWarwick 2020.
+Note that the coordinators positions will be filled first, so your application
+will only be reviewed after this. You may apply for both a Coordinator and
+Director position.

--- a/_collections/_recruitment/directors.md
+++ b/_collections/_recruitment/directors.md
@@ -1,27 +1,199 @@
 ---
 title: Directors
-form: director-recruitment-2019
+form: director-recruitment-2020
 
-year: 2019
+year: 2020
 
-status: closed  # One of open, closed or future
+status: open  # One of open, closed or future
 
 brief:
   open: |
     A total of 8 directors take leading roles in the organisation of
     TEDxWarwick together with their respective teams. Applications for these
     positions are now open and will be considered on a rolling basis.
-    Applications will be reviewed by the TEDxWarwick 2019 Coordinators, once
+    Applications will be reviewed by the TEDxWarwick 2020 Coordinators, once
     they have been appointed.
 
   closed: |
-    Applications for Director positions for 2019 have now closed.
+    Applications for Director positions for 2020 have now closed.
 
   future: |
-    Applications for Director positions for 2019 are not yet open.
+    Applications for Director positions for 2020 are not yet open.
+
+sections:
+  - name: operations
+    label: Director of Operations
+    description: |
+      The Operations Team is responsible for the flawless execution of
+      TEDxWarwick 2020\. This includes, but is not limited to: venue, catering,
+      speaker travel and volunteer management. The Operations team works
+      closely with the other TEDxWarwick teams to ensure that all logistics
+      and operations are in order. The Director must be able to communicate
+      effectively with service providers, coordinate a team quickly and
+      efficiently and be able to deal with unexpected problems. Due to the
+      nature of the work, the Director of Operations must be able to dedicate
+      large amounts of time in the weeks leading up to the event.
+
+      ##### Applicants must:
+
+       - Understand the various components that form event management
+       - Have strong organisational skills, with previous experience in
+         organising events
+       - Have excellent attention to detail
+       - Have strong communication and problem solving skills
+       - Be flexible, passionate and willing to take the initiative
+
+  - name: content
+    label: Director of Content
+    description: |
+      The Content Team are tasked with the selection and curation of all
+      speakers. The Director of Content must have an extensive network and be
+      confident and committed to the ethos of TED, with a vision of bringing
+      the world's greatest thinkers and doers (from both within and without the
+      University) to the 2020 events. Other responsibilities include leading
+      speaker preparation and speaker hospitality, working closely with all
+      speakers throughout content development to make sure all arrangements are
+      met and content is rehearsed to ensure speakers give the best talk of
+      their life.
+
+      The Content Team is responsible for suggesting and contacting potential
+      speakers for the main TEDxWarwick conference and for the three
+      TEDxWarwick salon events, and the Director is responsible for leading
+      this effort from Term 3 onwards.  We are therefore looking for candidates
+      with the following qualities:
+
+       - Excellent research skills
+       - Exceptional communication and leadership skills
+       - Ability to remain committed and focused in the face of regular
+         disappointment
+       - Capacity to rapidly synthesise information and accurately offer
+         constructive feedback to further develop speakers' content
+       - A high level of professionalism
+       - An excellent comprehension of the English language
+
+  - name: marketing
+    label: Director of Marketing
+    description: |
+      The Marketing team works towards moulding the public perception and the
+      branding of TEDxWarwick, in and around the Warwick community, through the
+      promotion of our event as well as the TED ethos. The team's
+      responsibilities include executing a high quality on-campus and social
+      media advertising strategy, creating content for the blog and newsletter
+      and running outreach programmes that further TEDxWarwick's presence in
+      the local community. The Director of Marketing must therefore be able to
+      lead the team's marketing efforts and liaise between the Marketing Team
+      and other TEDxWarwick teams (in particular Creative).
+
+      We are therefore looking for applicants who:
+
+       - Can effectively communicate ideas, both verbally and in written form
+       - Have creative ability and original ideas
+       - Understand the broad audience of TEDxWarwick
+       - Have previous experience running a marketing campaign
+       - Have experience managing social media channels
+       - Are able to manage and execute large marketing strategies
+
+  - name: corporate-relations
+    label: Director of Corporate Relations
+    description: |
+      The Corporate Relations Team focuses on creating and maintaining strong
+      partnership relations with sponsors and with the press. This is an
+      ongoing process throughout the year and requires a Director who is
+      committed to working intimately with our sponsors, both inside and
+      outside the University, from term 3\. We are therefore looking for
+      applicants who:
+
+       - Are professional, persuasive and confident in their interactions with
+         the companies that we deal with; previous sponsorship experience is
+         welcomed but not a prerequisite
+       - Have strong written and verbal communication skills and attention to
+         detail when interacting with external firms
+       - Have a holistic understanding and interest in what drives TEDxWarwick
+         and what makes it valuable to sponsors and the press
+
+  - name: creative
+    label: Creative Director
+    description: |
+      The Creative Director is responsible for the overall direction of all
+      design aspects of the event, ensuring that all work is of high quality
+      and consistent style. The Creative team's responsibilities include design
+      of posters and marketing material, speaker and sponsorship packs, the
+      TEDxWarwick 2020 Magazine, stage and foyer design, creating photo and
+      video content and coordinating the design of the website with the
+      Technical Director. A successful applicant must:
+
+       - Be willing to dedicate a fair portion of their time throughout the
+         year towards creating visual elements for the TEDxWarwick brand
+       - Have an eye for detail, with the ability to curate visual elements as
+         a means to promote our events
+       - Desirable to have experience in at least one of the following
+         programs: Photoshop, Illustrator or InDesign
+       - Have good communication skills, being able to coordinate both the
+         Creative Team and with other TEDxWarwick teams
+
+  - name: technical
+    label: Technical Director
+    description: |
+      The role of Technical Director involves designing and maintaining our
+      extensive website, as well as coordinating the technical aspects of
+      TEDxWarwick events. The Technical Director works closely with the
+      Creative, Marketing and Operations teams, and in particular liaises with
+      departments of the University of Warwick and the Warwick Arts Centre in
+      the build up to our main event.
+
+      ##### We are looking for someone who:
+
+       - Has a working knowledge of videography including use of cine cameras,
+         lens selection and lighting
+       - Has experience in website design, with knowledge of HTML5, CSS3,
+         Javascript and GitHub
+       - Is willing to devote a significant amount of time to prepare for each
+         event, and to maintain/update our website in between.
+
+  - name: publications
+    label: Director of Publications
+    description: |
+      Since we introduced the inaugural TEDxWarwick Magazine in 2014, we are
+      looking for a Director of Publications, responsible for editing and
+      curating the content of our 2020 magazine. The magazine is comprised of
+      information about the team and event, articles from previous speakers,
+      articles on the year's theme and more, and also includes interactive
+      content on our website accessible using links printed in the magazine.
+
+      Therefore, a successful applicant for the role of Director of
+      Publications must:
+
+       - Have a strong understanding of the TED ethos and a vision for
+         TEDxWarwick publications
+       - Have an exceptional competency and understanding of the English
+         language and the written word
+       - Have good communication skills for liaising with the Technical
+         Director, and Creative Team on the design of both the printed
+         publication and interactive magazine
+       - Preferably have previous experience working on a printed magazine or
+         book, but this is not essential
+       - Have excellent time management skills
+
+  - name: treasurer
+    label: Treasurer
+    description: |
+      The role of Treasurer is a combined administrative and treasurer role.
+      The Treasurer is responsible for ensuring the smooth running of the
+      administrative side of the event organising process. Duties include
+      managing the budget, scheduling meetings, taking detailed and accurate
+      minutes, ensuring deadlines are kept to and liaising with the Warwick SU
+      on administrative and financial matters.
+
+      We are therefore looking for an applicant who:
+
+       - Has excellent organisational skills
+       - Has proficiency in financial administration
+       - Is reliable and punctual
+       - Preferably, but not essentially, has familiarity with Warwick SU's
+         finance and administration system
 ---
 
-### TEDxWarwick 2019 Director Recruitment
+### TEDxWarwick 2020 Director Recruitment
 
 TEDxWarwick is one of the largest TEDx events in Europe. An annual event,
 TEDxWarwick takes place in the well-renowned Warwick Arts Centre, attracting an
@@ -42,168 +214,3 @@ in some cases a deputy or vice director as well). We are pleased to announce
 that applications for our director positions are now open. All students,
 undergraduate and postgraduate, are eligible to apply for a position. The
 particular details of each team are described below:
-
-<section id="team-operations">
-#### Director of Operations
-The Operations Team is responsible for the flawless execution of TEDxWarwick
-2019\. This includes, but is not limited to: venue, catering, speaker travel
-and volunteer management. The Operations team works closely with the other
-TEDxWarwick teams to ensure that all logistics and operations are in order. The
-Director must be able to communicate effectively with service providers,
-coordinate a team quickly and efficiently and be able to deal with unexpected
-problems. Due to the nature of the work, the Director of Operations must be
-able to dedicate large amounts of time in the weeks leading up to the event.
-
-##### Applicants must:
-- Understand the various components that form event management
-- Have strong organisational skills, with previous experience in organising
-  events
-- Have excellent attention to detail
-- Have strong communication and problem solving skills
-- Be flexible, passionate and willing to take the initiative
-</section>
-
-<section id="team-content">
-#### Director of Content
-The Content Team are tasked with the selection and curation of all speakers.
-The Director of Content must have an extensive network and be confident and
-committed to the ethos of TED, with a vision of bringing the world's greatest
-thinkers and doers (from both within and without the University) to the 2019
-events. Other responsibilities include leading speaker preparation and speaker
-hospitality, working closely with all speakers throughout content development
-to make sure all arrangements are met and content is rehearsed to ensure
-speakers give the best talk of their life.
-
-The Content Team is responsible for suggesting and contacting potential
-speakers for the main TEDxWarwick conference and for the three TEDxWarwick
-salon events, and the Director is responsible for leading this effort from
-Term 3 onwards.  We are therefore looking for candidates with the following
-qualities:
-
-- Excellent research skills
-- Exceptional communication and leadership skills
-- Ability to remain committed and focused in the face of regular disappointment
-- Capacity to rapidly synthesise information and accurately offer constructive
-  feedback to further develop speakers' content
-- A high level of professionalism
-- An excellent comprehension of the English language
-</section>
-
-<section id="team-marketing">
-#### Director of Marketing
-The Marketing team works towards moulding the public perception and the
-branding of TEDxWarwick, in and around the Warwick community, through the
-promotion of our event as well as the TED ethos. The team's responsibilities
-include executing a high quality on-campus and social media advertising
-strategy, creating content for the blog and newsletter and running outreach
-programmes that further TEDxWarwick's presence in the local community. The
-Director of Marketing must therefore be able to lead the team's marketing
-efforts and liaise between the Marketing Team and other TEDxWarwick teams (in
-particular Creative).
-
-We are therefore looking for applicants who:
-
-- Can effectively communicate ideas, both verbally and in written form
-- Have creative ability and original ideas
-- Understand the broad audience of TEDxWarwick
-- Have previous experience running a marketing campaign
-- Have experience managing social media channels
-- Are able to manage and execute large marketing strategies
-</section>
-
-<section id="team-corporate-relations">
-#### Director of Corporate Relations
-The Corporate Relations Team focuses on creating and maintaining strong
-partnership relations with sponsors and with the press. This is an ongoing
-process throughout the year and requires a Director who is committed to working
-intimately with our sponsors, both inside and outside the University, from term
-3\. We are therefore looking for applicants who:
-
-- Are professional, persuasive and confident in their interactions with the
-  companies that we deal with; previous sponsorship experience is welcomed but
-  not a prerequisite
-- Have strong written and verbal communication skills and attention to detail
-  when interacting with external firms
-- Have a holistic understanding and interest in what drives TEDxWarwick and
-  what makes it valuable to sponsors and the press
-</section>
-
-<section id="team-creative">
-#### Creative Director
-The Creative Director is responsible for the overall direction of all design
-aspects of the event, ensuring that all work is of high quality and consistent
-style. The Creative team's responsibilities include design of posters and
-marketing material, speaker and sponsorship packs, the TEDxWarwick 2019
-Magazine, stage and foyer design, creating photo and video content and
-coordinating the design of the website with the Technical Director. A
-successful applicant must:
-
-- Be willing to dedicate a fair portion of their time throughout the year
-  towards creating visual elements for the TEDxWarwick brand
-- Have an eye for detail, with the ability to curate visual elements as a means
-  to promote our events
-- Desirable to have experience in at least one of the following programs:
-  Photoshop, Illustrator or InDesign
-- Have good communication skills, being able to coordinate both the Creative
-  Team and with other TEDxWarwick teams
-</section>
-
-<section id="team-technical">
-#### Technical Director
-The role of Technical Director involves designing and maintaining our extensive
-website, as well as coordinating the technical aspects of TEDxWarwick events.
-The Technical Director works closely with the Creative, Marketing and
-Operations teams, and in particular liaises with departments of the University
-of Warwick and the Warwick Arts Centre in the build up to our main event.
-
-We are looking for someone who:
-
-- Has a working knowledge of videography including use of cine cameras, lens
-  selection and lighting
-- Has experience in website design, with knowledge of HTML5, CSS3, Javascript
-  and GitHub
-- Is willing to devote a significant amount of time to prepare for each event,
-   and to maintain/update our website in between.
-</section>
-
-<section id="team-publications">
-#### Director of Publications
-Since we introduced the inaugural TEDxWarwick Magazine in 2014, we are looking
-for a Director of Publications, responsible for editing and curating the
-content of our 2019 magazine. The magazine is comprised of information about
-the team and event, articles from previous speakers, articles on the year's
-theme and more, and also includes interactive content on our website accessible
-using links printed in the magazine.
-
-Therefore, a successful applicant for the role of Director of Publications
-must:
-
-- Has a strong understanding of the TED ethos and a vision for TEDxWarwick
-  publications
-- Have an exceptional competency and understanding of the English language and
-  the written word
-- Have good communication skills for liaising with the Technical Director, and
-  Creative Team on the design of both the printed publication and interactive
-  magazine
-- Preferably have previous experience working on a printed magazine or book,
-  but this is not essential
-- Have excellent time management skills
-</section>
-
-<section id="team-treasurer">
-#### Treasurer
-The role of Treasurer is a combined administrative and treasurer role. The
-Treasurer is responsible for ensuring the smooth running of the administrative
-side of the event organising process. Duties include managing the budget,
-scheduling meetings, taking detailed and accurate minutes, ensuring deadlines
-are kept to and liaising with the Warwick SU on administrative and financial
-matters.
-
-We are therefore looking for an applicant who:
-
-- Has excellent organisational skills
-- Has proficiency in financial administration
-- Is reliable and punctual
-- Preferably, but not essentially, has familiarity with Warwick SU's finance
-  and administration system
-</section>

--- a/_collections/_recruitment/speakers.md
+++ b/_collections/_recruitment/speakers.md
@@ -2,20 +2,20 @@
 title: Open speaker applications
 form: speaker-apps
 
-year: 2019
+year: 2020
 
 status: open
 
 brief:
   open: |
-    Continuing from TEDxWarwick 2018, we are looking for speakers and
-    performers for our upcoming 2019 conference. Applications will be accepted
+    Continuing from TEDxWarwick 2019, we are looking for speakers and
+    performers for our upcoming 2020 conference. Applications will be accepted
     from all backgrounds, from all over the UK. For more information, see
     [TED's FAQ](http://conferences.ted.com/TED2013/auditions/faq.php).
 
   closed: |
     We're not currently accepting applications for speakers at TEDxWarwick
-    2019.
+    2020.
 
   future: |
     Soon we will be opening applications for speakers at our main event. For
@@ -24,8 +24,8 @@ brief:
 
 ## Open Speaker Applications
 
-Continuing from TEDxWarwick 2018, we are looking for speakers and performers
-for our upcoming 2018 conference. Applications will be accepted from all
+Continuing from TEDxWarwick 2019, we are looking for speakers and performers
+for our upcoming 2020 conference. Applications will be accepted from all
 backgrounds, from all over the UK. For more information, see
 [TED's FAQ](http://conferences.ted.com/TED2013/auditions/faq.php).
 
@@ -59,7 +59,7 @@ possible. Applications will be reviewed on a rolling basis, and applying early
 may be beneficial. You have the option of attaching a video file with a maximum
 length of two minutes. The submission will be reviewed by our Content Team, who
 will reply by email. Please aim to be concise, limiting your answers to
-approximately 150 words per question. Please note that we review applications on 
-a rolling basis for all of our events during the academic year. Unfortunately, 
-due to the very large volume of applications we receive, we are only able to 
+approximately 150 words per question. Please note that we review applications on
+a rolling basis for all of our events during the academic year. Unfortunately,
+due to the very large volume of applications we receive, we are only able to
 reply to successful candidates. Thank you for your interest - and good luck!

--- a/_collections/_recruitment/student-speakers.md
+++ b/_collections/_recruitment/student-speakers.md
@@ -2,9 +2,9 @@
 title: Student speakers
 form: student-speakers-2019
 
-year: 2019
+year: 2020
 
-status: closed
+status: future
 
 brief:
   open: |
@@ -13,7 +13,7 @@ brief:
     now open!
 
   closed: |
-    Applications for student speakers for 2019 have now closed. Many thanks to
+    Applications for student speakers for 2020 have now closed. Many thanks to
     all those who applied, we will review each application carefully and get
     back to you shortly.
 
@@ -29,7 +29,7 @@ redirect_from:
 
 Following the success of our first-ever Student Salon at the beginning of 2017
 and our second edition in 2018, we are now looking for speakers and performers
-for our upcoming Student Salon in January 2019.
+for our upcoming Student Salon in January 2020.
 
 You can apply to be a speaker, a performer or a hybrid (speaker with some
 performance elements).

--- a/_collections/_recruitment/team.md
+++ b/_collections/_recruitment/team.md
@@ -2,9 +2,9 @@
 title: Team members
 form: team-recruitment-2019
 
-year: 2019
+year: 2020
 
-status: closed
+status: future
 
 brief:
   open: |
@@ -13,7 +13,7 @@ brief:
     members are now open!
 
   closed: |
-    Applications for team members for 2019 have now closed. Many thanks to all
+    Applications for team members for 2020 have now closed. Many thanks to all
     those who applied, we will review each application carefully and get back
     to you shortly.
 
@@ -125,7 +125,7 @@ sections:
     label: Operations
     description: |
       The Operations team is responsible for the flawless execution of
-      TEDxWarwick 2019. This includes -- and is not limited to -- organising
+      TEDxWarwick 2020. This includes -- and is not limited to -- organising
       the venue, catering, ticketing and volunteer management. You will be
       working closely with the other TEDxWarwick teams to ensure that all
       logistics and operations are in order. An Operations team member must be
@@ -149,7 +149,7 @@ sections:
       We successfully introduced the TEDxWarwick Magazine in 2014 and have
       issued it every year since. Therefore, we are looking for a few team
       members to join our publications team, which is responsible for editing
-      and curating the content of the TEDxWarwick 2019 magazine and blog. They
+      and curating the content of the TEDxWarwick 2020 magazine and blog. They
       include information and articles about the main event, history of the
       society, salon events, past and future speakers -- basically anything
       that might be relevant to TEDxWarwick. We are looking for someone who:
@@ -174,7 +174,7 @@ sections:
       website, as well as various technical aspects of the live events. We work
       closely with the Creative and Marketing teams, and in particular liaise
       with departments of the University and the Warwick Arts Centre in the
-      run-up to our main event. Our main aim for 2019 is to improve the quality
+      run-up to our main event. Our main aim for 2020 is to improve the quality
       and consistency of our live recordings.
 
       The following skills are preferable but not essential; anyone with an

--- a/_collections/_recruitment/volunteers.md
+++ b/_collections/_recruitment/volunteers.md
@@ -2,9 +2,9 @@
 title: Volunteers
 form: volunteers-2019
 
-year: 2019
+year: 2020
 
-status: closed
+status: future
 
 brief:
   open: |
@@ -13,7 +13,7 @@ brief:
     Applications for volunteers at our flagship event are now open!
 
   closed: |
-    Applications for volunteers for 2019 have now closed. Many thanks to all
+    Applications for volunteers for 2020 have now closed. Many thanks to all
     those who applied, we will review each application carefully and get back
     to you shortly.
 
@@ -26,9 +26,9 @@ redirect_from:
   /get-involved/volunteer
 ---
 
-## Volunteer at TEDxWarwick 2019
+## Volunteer at TEDxWarwick 2020
 
-#### We want to make TEDxWarwick 2019 our best conference yet!
+#### We want to make TEDxWarwick 2020 our best conference yet!
 
 The scale of initiatives we are running this year mean that we will need your
 support in the coming weeks leading up to our flagship conference for 2019,

--- a/_layouts/recruitment.html
+++ b/_layouts/recruitment.html
@@ -11,7 +11,7 @@ layout: default
 
 {% for section in page.sections -%}
   <section id="section-{{ section.name }}">
-    <h3>{{ section.label }}</h3>
+    <h4>{{ section.label }}</h4>
     {% if section.description -%}
       {{ section.description | markdownify }}
     {%- else -%}


### PR DESCRIPTION
### Describe your changes
<!-- A clear and concise description of your changes. -->

 - Update all 2019 references in recruitment pages to 2020
 - Make recruitment description section headers `<h4>` instead of `<h3>`
 - Add forms for 2020 coordinator & director recruitment and mark as `open`
 - Change all remaining `closed` to `future`

### Side effects of your changes
<!-- A clear and concise description of any potentially unexpected results. -->

None.

### Additional context
<!-- Add any other context about the fix here. -->
